### PR TITLE
Allow multiple ID columns.

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -151,7 +151,7 @@ const apolloCursorPaginationBuilder = ({
   let edges = convertNodesToEdges(nodes, {
     before, after, first, last,
   }, {
-    orderColumn, ascOrDesc, isAggregateFn, formatColumnFn,
+    idColumn, orderColumn, ascOrDesc, isAggregateFn, formatColumnFn,
   });
   if (modifyEdgeFn) {
     edges = edges.map(edge => modifyEdgeFn(edge));


### PR DESCRIPTION
ID columns are the backup sort that is used after the primary sorts.  This makes sure the rows come back consistently each time.  This lets us sort on tables that have a composite primary key (e.g. join tables).