### PR TITLE
Change the package.json's main source from dist/ to src/.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apollo-cursor-pagination",
   "version": "0.7.0",
   "description": "Relay's Connection implementation for Apollo Server GraphQL library",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "repository": "https://github.com/promotedai/apollo-cursor-pagination",
   "author": "Daniel Merrill <daniel@terminal.co>",
   "license": "MIT",


### PR DESCRIPTION
We don't need the build structure since we'll be including the js and building ourselves.